### PR TITLE
Fix json format during export

### DIFF
--- a/index-backup-restore/v11/AzureSearchBackupRestoreIndex/Program.cs
+++ b/index-backup-restore/v11/AzureSearchBackupRestoreIndex/Program.cs
@@ -159,7 +159,7 @@ class Program
             }
 
             // Output the formatted content to a file
-            json = json.Substring(0, json.Length - 3); // remove trailing comma
+            json = json.Substring(0, json.Length - 2); // remove trailing comma
             File.WriteAllText(FileName, "{\"value\": [");
             File.AppendAllText(FileName, json);
             File.AppendAllText(FileName, "]}");


### PR DESCRIPTION
I faced this issue https://github.com/Azure-Samples/azure-search-dotnet-utilities/issues/24 and it was caused because the last comma removal was also removing the last doc closing `}` creating an invalid JSON which was causing the bad request in the Azure Search REST API call

_Incorrect exported json format with missing '}' in the last doc item_
![image](https://github.com/user-attachments/assets/45856912-053b-48db-bd59-7b56de410be5)
